### PR TITLE
Ubuntu: add missing qemu-img to path

### DIFF
--- a/debian/default.nix
+++ b/debian/default.nix
@@ -33,8 +33,8 @@ let
 
       # virt-resize depends on qemu-img, which is part of the qemu
       # derivation
-      export PATH="${pkgs.qemu}/bin:$PATH"
       ${lib.optionalString (diskSize != null) ''
+        export PATH="${pkgs.qemu}/bin:$PATH"
         qemu-img resize ${resultImg} ${diskSize}
       ''}
 

--- a/ubuntu/default.nix
+++ b/ubuntu/default.nix
@@ -32,6 +32,7 @@ let
       cp ${generic.resizeService} resizeguest.service
 
       ${lib.optionalString (diskSize != null) ''
+        export PATH="${pkgs.qemu}/bin:$PATH"
         qemu-img resize ${resultImg} +2G
         systemctl enable resizeguest.service
       ''}


### PR DESCRIPTION
I should really test this on CI. TODO