### PR TITLE
Remove VM name option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,10 @@ The API is very WIP/unstable, do not expect much stability for now.
 
 ```nix
 nix-vm-test.lib.ubuntu."23_04" {
-  name = "example";
   sharedDirs = {
   };
   testScript = ''
-    example.wait_for_unit("multi-user.target")
+    vm.wait_for_unit("multi-user.target")
   '';
   };
 }

--- a/debian/default.nix
+++ b/debian/default.nix
@@ -6,8 +6,8 @@ let
     url = "https://cloud.debian.org/images/cloud/${image.name}";
   };
   images = lib.mapAttrs (k: v: fetchImage v) imagesJSON.${system};
-  makeVmTestForImage = image: { testScript, name, sharedDirs, diskSize ? null }: generic.makeVmTest {
-    inherit system testScript name sharedDirs;
+  makeVmTestForImage = image: { testScript, sharedDirs, diskSize ? null }: generic.makeVmTest {
+    inherit system testScript sharedDirs;
     image = prepareDebianImage {
       inherit diskSize;
       hostPkgs = pkgs;

--- a/fedora/default.nix
+++ b/fedora/default.nix
@@ -6,8 +6,8 @@ let
     url = "https://download.fedoraproject.org/pub/fedora/linux/releases/${image.name}";
   };
   images = lib.mapAttrs (k: v: fetchImage v) imagesJSON.${system};
-  makeVmTestForImage = image: { testScript, name, sharedDirs, diskSize ? null }: generic.makeVmTest {
-    inherit system testScript name sharedDirs;
+  makeVmTestForImage = image: { testScript, sharedDirs, diskSize ? null }: generic.makeVmTest {
+    inherit system testScript sharedDirs;
     image = prepareFedoraImage {
       inherit diskSize;
       hostPkgs = pkgs;

--- a/generic/default.nix
+++ b/generic/default.nix
@@ -1,8 +1,7 @@
 { lib, pkgs, nixpkgs }:
 rec {
-  defaultMachineConfigModule = name: { ... }: {
+  defaultMachineConfigModule = { ... }: {
     nodes = {
-      vm.system.name = name;
     };
   };
   printAttrPos = { file, line, column }: "${file}:${toString line}:${toString column}";
@@ -115,8 +114,7 @@ rec {
     , image
     , testScript
     , sharedDirs
-    , machineConfigModule ? (defaultMachineConfigModule name)
-    , name
+    , machineConfigModule ? defaultMachineConfigModule
     }:
     let
       hostPkgs = pkgs;
@@ -137,7 +135,7 @@ rec {
         ${lib.concatStringsSep "\n"
         (lib.mapAttrsToList
         (tag: share:
-        "${name}.succeed('mkdir -p ${share.target} && mount -t 9p -o defaults,trans=virtio,version=9p2000.L,cache=loose,msize=${toString (256 * 1024 * 1024)} ${tag} ${share.target}')")
+        "$vm.succeed('mkdir -p ${share.target} && mount -t 9p -o defaults,trans=virtio,version=9p2000.L,cache=loose,msize=${toString (256 * 1024 * 1024)} ${tag} ${share.target}')")
         sharedDirs)}
       '' + testScript;
 
@@ -160,7 +158,7 @@ rec {
         # The test driver extracts the name of the node from the name of the
         # VM script, so it's important here to stick to the naming scheme expected
         # by the test driver.
-      in hostPkgs.writeShellScript "run-${node.system.name}-vm"
+      in hostPkgs.writeShellScript "run-vm"
          ''
           set -eo pipefail
 
@@ -184,7 +182,7 @@ rec {
             "exec ${lib.getBin qemupkg}/bin/qemu-kvm"
             "-device virtio-rng-pci"
             "-cpu max"
-            "-name ${node.system.name}"
+            "-name vm"
             "-m ${toString node.virtualisation.memorySize}"
             "-smp ${toString node.virtualisation.cpus}"
             "-drive file=${image},format=qcow2"
@@ -218,7 +216,6 @@ rec {
       };
     in
     hostPkgs.stdenv.mkDerivation {
-      inherit name;
 
       requiredSystemFeatures = [ "kvm" "nixos-test" ];
 

--- a/generic/module.nix
+++ b/generic/module.nix
@@ -11,11 +11,6 @@ let
 
   nodeOptions = { config, name, ... }: {
     options = {
-      system.name = lib.mkOption {
-        type = types.str;
-        default = name;
-      };
-
       virtualisation = {
         rootImage = lib.mkOption {
           type = types.package;

--- a/tests/debian.nix
+++ b/tests/debian.nix
@@ -14,10 +14,9 @@ let
     lib.debian.images;
 in {
   resizeImage = lib.debian."13" {
-    name = "test_debian_size";
     sharedDirs = {};
     testScript = ''
-      test_debian_size.wait_for_unit("multi-user.target")
+      vm.wait_for_unit("multi-user.target")
     '';
     diskSize = "+2M";
   };
@@ -32,7 +31,6 @@ in {
       echo "hello2" > $out/somefile2
     '';
   in lib.debian."13" {
-    name = "shared_dir_test";
     sharedDirs = {
       dir1 = {
         source = "${dir1}";
@@ -44,10 +42,10 @@ in {
       };
     };
     testScript = ''
-      shared_dir_test.wait_for_unit("multi-user.target")
-      shared_dir_test.succeed('ls /tmp/dir1')
-      shared_dir_test.succeed('test "$(cat /tmp/dir1/somefile1)" == "hello1"')
-      shared_dir_test.succeed('test "$(cat /tmp/dir2/somefile2)" == "hello2"')
+      vm.wait_for_unit("multi-user.target")
+      vm.succeed('ls /tmp/dir1')
+      vm.succeed('test "$(cat /tmp/dir1/somefile1)" == "hello1"')
+      vm.succeed('test "$(cat /tmp/dir2/somefile2)" == "hello2"')
     '';
   };
 } //

--- a/tests/fedora.nix
+++ b/tests/fedora.nix
@@ -2,10 +2,9 @@
 let
   lib = package.${system};
   multiUserTest = runner: runner {
-    name = "multiuser";
     sharedDirs = {};
     testScript = ''
-      multiuser.wait_for_unit("multi-user.target")
+      vm.wait_for_unit("multi-user.target")
     '';
   };
   runTestOnEveryImage = name: test:
@@ -14,10 +13,9 @@ let
     lib.fedora.images;
 in {
   resizeImage = lib.fedora."39" {
-    name = "test_fedora_size";
     sharedDirs = {};
     testScript = ''
-      test_fedora_size.wait_for_unit("multi-user.target")
+      vm.wait_for_unit("multi-user.target")
     '';
     diskSize = "+2M";
   };
@@ -32,7 +30,6 @@ in {
       echo "hello2" > $out/somefile2
     '';
   in lib.fedora."39" {
-    name = "shared_dir_test";
     sharedDirs = {
       dir1 = {
         source = "${dir1}";
@@ -44,10 +41,10 @@ in {
       };
     };
     testScript = ''
-      shared_dir_test.wait_for_unit("multi-user.target")
-      shared_dir_test.succeed('ls /tmp/dir1')
-      shared_dir_test.succeed('test "$(cat /tmp/dir1/somefile1)" == "hello1"')
-      shared_dir_test.succeed('test "$(cat /tmp/dir2/somefile2)" == "hello2"')
+      vm.wait_for_unit("multi-user.target")
+      vm.succeed('ls /tmp/dir1')
+      vm.succeed('test "$(cat /tmp/dir1/somefile1)" == "hello1"')
+      vm.succeed('test "$(cat /tmp/dir2/somefile2)" == "hello2"')
     '';
   };
 } //

--- a/tests/ubuntu.nix
+++ b/tests/ubuntu.nix
@@ -15,7 +15,6 @@ let
     lib.ubuntu.images;
 in {
   resizeImage = lib.ubuntu."23_04" {
-    name = "test_ubuntu_size";
     sharedDirs = {};
     testScript = ''
       test_ubuntu_size.wait_for_unit("multi-user.target")
@@ -33,7 +32,6 @@ in {
       echo "hello2" > $out/somefile2
     '';
   in lib.ubuntu."23_04" {
-    name = "shared_dir_test";
     sharedDirs = {
       dir1 = {
         source = "${dir1}";

--- a/ubuntu/default.nix
+++ b/ubuntu/default.nix
@@ -6,8 +6,8 @@ let
     url = "https://cloud-images.ubuntu.com/releases/${image.releaseName}/release-${image.releaseTimeStamp}/${image.name}";
   };
   images = lib.mapAttrs (k: v: fetchImage v) imagesJSON.${system};
-  makeVmTestForImage = image: { testScript, name, sharedDirs, diskSize ? null }: generic.makeVmTest {
-    inherit system testScript name sharedDirs;
+  makeVmTestForImage = image: { testScript, sharedDirs, diskSize ? null }: generic.makeVmTest {
+    inherit system testScript sharedDirs;
     image = prepareUbuntuImage {
       inherit diskSize;
       hostPkgs = pkgs;


### PR DESCRIPTION
We currently do not support multi-machines setups. The name is just a footgun: it ends up in a Python variable. Set it up to any value that is not compatible with a Python variable and you'll end up with a puzzling error message.

Let's remove it and replace it with a simple "vm".