### PR TITLE
API: redesign outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@ The API is very WIP/unstable, do not expect much stability for now.
 ## Usage
 
 ```nix
-nix-vm-test.lib.ubuntu."23_04" {
-  sharedDirs = {
-  };
-  testScript = ''
-    vm.wait_for_unit("multi-user.target")
-  '';
-  };
+let
+  test = nix-vm-test.lib.ubuntu."23_04" {
+    sharedDirs = {};
+    testScript = ''
+      vm.wait_for_unit("multi-user.target")
+    '';
+    };
+in test.sandboxed
 }
 ```
 

--- a/generic/default.nix
+++ b/generic/default.nix
@@ -214,26 +214,24 @@ rec {
         inherit interactive nodes;
         vlans = [ "1" ];
       };
-    in
-    hostPkgs.stdenv.mkDerivation {
-      name = "vm-test";
-
-      requiredSystemFeatures = [ "kvm" "nixos-test" ];
-
-      buildCommand = ''
-        ${defaultTest {}}
-        touch $out
-      '';
-
-      passthru = {
-        driver = hostPkgs.writeShellScriptBin "test-driver"
-          (defaultTest {
-            interactive = false;
-          });
-        driverInteractive = hostPkgs.writeShellScriptBin "test-driver"
-          (defaultTest {
-            interactive = true;
-          });
+    in {
+      sandboxed = hostPkgs.stdenv.mkDerivation {
+        name = "vm-test";
+        requiredSystemFeatures = [ "kvm" "nixos-test" ];
+        buildCommand = ''
+          ${defaultTest {}}
+          touch $out
+        '';
       };
+
+      driver = hostPkgs.writeShellScriptBin "test-driver"
+      (defaultTest {
+        interactive = false;
+      });
+
+      driverInteractive = hostPkgs.writeShellScriptBin "test-driver"
+      (defaultTest {
+        interactive = true;
+      });
     };
 }

--- a/tests/debian.nix
+++ b/tests/debian.nix
@@ -1,24 +1,24 @@
 { pkgs, package, system }:
 let
   lib = package.${system};
-  multiUserTest = runner: runner {
+  multiUserTest = runner: (runner {
     sharedDirs = {};
     testScript = ''
       vm.wait_for_unit("multi-user.target")
     '';
-  };
+  }).sandboxed;
   runTestOnEveryImage = test:
     pkgs.lib.mapAttrs'
     (n: v: pkgs.lib.nameValuePair "${n}-multi-user-test" (test lib.debian.${n}))
     lib.debian.images;
 in {
-  resizeImage = lib.debian."13" {
+  resizeImage = (lib.debian."13" {
     sharedDirs = {};
     testScript = ''
       vm.wait_for_unit("multi-user.target")
     '';
     diskSize = "+2M";
-  };
+  }).sandboxed;
 
   sharedDirTest = let
     dir1 = pkgs.runCommandNoCC "dir1" {} ''

--- a/tests/fedora.nix
+++ b/tests/fedora.nix
@@ -1,12 +1,12 @@
 { pkgs, package, system }:
 let
   lib = package.${system};
-  multiUserTest = runner: runner {
+  multiUserTest = runner: (runner {
     sharedDirs = {};
     testScript = ''
       vm.wait_for_unit("multi-user.target")
     '';
-  };
+  }).sandboxed;
   runTestOnEveryImage = test:
     pkgs.lib.mapAttrs'
     (n: v: pkgs.lib.nameValuePair "${n}-multi-user-test" (test lib.fedora.${n}))
@@ -29,7 +29,7 @@ in {
       mkdir -p $out
       echo "hello2" > $out/somefile2
     '';
-  in lib.fedora."39" {
+  in (lib.fedora."39" {
     sharedDirs = {
       dir1 = {
         source = "${dir1}";
@@ -46,7 +46,7 @@ in {
       vm.succeed('test "$(cat /tmp/dir1/somefile1)" == "hello1"')
       vm.succeed('test "$(cat /tmp/dir2/somefile2)" == "hello2"')
     '';
-  };
+  }).sandboxed;
 } //
 runTestOnEveryImage multiUserTest //
 package.${system}.fedora.images

--- a/tests/ubuntu.nix
+++ b/tests/ubuntu.nix
@@ -2,24 +2,24 @@
 
 let
   lib = package.${system};
-  multiUserTest = runner: runner {
+  multiUserTest = runner: (runner {
     sharedDirs = {};
     testScript = ''
       vm.wait_for_unit("multi-user.target")
     '';
-  };
+  }).sandboxed;
   runTestOnEveryImage = test:
     pkgs.lib.mapAttrs'
     (n: v: pkgs.lib.nameValuePair "${n}-multi-user-test" (test lib.ubuntu.${n}))
     lib.ubuntu.images;
 in {
-  resizeImage = lib.ubuntu."23_04" {
+  resizeImage = (lib.ubuntu."23_04" {
     sharedDirs = {};
     testScript = ''
       vm.wait_for_unit("multi-user.target")
     '';
     diskSize = "+2M";
-  };
+  }).sandboxed;
 
   sharedDirTest = let
     dir1 = pkgs.runCommandNoCC "dir1" {} ''


### PR DESCRIPTION
So far, we had 3 outputs:

- .: the output running the VM test in the Nix daemon.
- driver: the output building the VM test to later run it outside of the daemon.
- driverInteractive: the output building an interactive VM test to interactively debug the VM test.

This was more or less the Nixpkgs semantics. Instead, we realize that we'd better off with an explicit "sandboxed" output to point out that the test won't have access to internet.

So now:

- driver and driverInteractive stay unchanged.
- sandboxed: the output running the VM test in the Nix daemon sandbox.