### PR TITLE
source: allow taking paths as arguments

### DIFF
--- a/generic/module.nix
+++ b/generic/module.nix
@@ -38,7 +38,7 @@ let
             (types.submodule {
               options = {
                 source = lib.mkOption {
-                  type = types.str;
+                  type = types.oneOf [ types.str types.path ];
                 };
                 target = lib.mkOption {
                   type = types.str;

--- a/tests/debian.nix
+++ b/tests/debian.nix
@@ -32,11 +32,11 @@ in {
   in (lib.debian."13" {
     sharedDirs = {
       dir1 = {
-        source = "${dir1}";
+        source = dir1;
         target = "/tmp/dir1";
       };
       dir2 = {
-        source = "${dir2}";
+        source = dir2;
         target = "/tmp/dir2";
       };
     };

--- a/tests/fedora.nix
+++ b/tests/fedora.nix
@@ -32,11 +32,11 @@ in {
   in (lib.fedora."39" {
     sharedDirs = {
       dir1 = {
-        source = "${dir1}";
+        source = dir1;
         target = "/tmp/dir1";
       };
       dir2 = {
-        source = "${dir2}";
+        source = dir2;
         target = "/tmp/dir2";
       };
     };

--- a/tests/ubuntu.nix
+++ b/tests/ubuntu.nix
@@ -33,11 +33,11 @@ in {
   in (lib.ubuntu."23_04" {
     sharedDirs = {
       dir1 = {
-        source = "${dir1}";
+        source = dir1;
         target = "/tmp/dir1";
       };
       dir2 = {
-        source = "${dir2}";
+        source = dir2;
         target = "/tmp/dir2";
       };
     };


### PR DESCRIPTION
The common case is to pass a path to the source, so let's just allow it as an argument.