### PR TITLE
Add overlay

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -270,3 +270,41 @@ $ ./result/bin/test-driver
 ```
 
 on your CI.
+
+## Using the Overlay
+
+If you would like to use this testing library with your own nixpkgs, use our
+overlay function.
+
+The overlay function makes all linux distributions available under the attribute
+`pkgs.testers.legacyDistros...`:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    nix-vm-test.url = "github:numtide/nix-vm-test";
+  };
+
+  outputs = { self, nixpkgs, nix-vm-test }:
+   let
+     system = "x86_64-linux";
+     pkgs = import nixpkgs {
+       inherit system;
+       overlays = [
+         nix-vm-test.overlays.default
+       ];
+     };
+    in
+      packages.x86_64-linux.mytest = pkgs.testers.legacyDistros.debian."13" {
+        sharedDirs.debDir = {
+          source = "${./.}";
+          target = "/mnt/debdir";
+        };
+        testScript = ''
+          vm.wait_for_unit("multi-user.target")
+          vm.succeed("apt-get -yq install /mnt/debdir/hello.deb")
+        '';
+      };
+}
+```

--- a/fedora/default.nix
+++ b/fedora/default.nix
@@ -5,7 +5,7 @@ let
     inherit (image) hash;
     url = "https://download.fedoraproject.org/pub/fedora/linux/releases/${image.name}";
   };
-  images = lib.mapAttrs (k: v: fetchImage v) imagesJSON.${system};
+  images = lib.mapAttrs (k: v: fetchImage v) (imagesJSON.${system} or {});
   makeVmTestForImage = image: { testScript, sharedDirs, diskSize ? null, extraPathsToRegister ? [ ]}: generic.makeVmTest {
     inherit system testScript sharedDirs;
     image = prepareFedoraImage {

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,22 @@
 {
   "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1708475490,
@@ -18,7 +35,23 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -5,11 +5,22 @@
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
   };
 
-  outputs = { self, nixpkgs, ... }: rec {
-    lib.x86_64-linux = import ./lib.nix {
-      inherit nixpkgs;
+  outputs = { self, nixpkgs, flake-utils }:
+    let
       system = "x86_64-linux";
+      pkgs = import nixpkgs {
+        overlays = [ self.overlays.default ];
+        localSystem = system;
+      };
+    in
+    {
+      lib.${system} = pkgs.testers.legacyDistros;
+
+      checks.${system} = import ./tests {
+        package = pkgs.testers.legacyDistros;
+        inherit pkgs system;
+      };
+
+      overlays.default = import ./overlay.nix;
     };
-    checks.x86_64-linux = import ./tests { package = lib; pkgs = nixpkgs.legacyPackages.x86_64-linux; system = "x86_64-linux"; };
-  };
 }

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,0 +1,17 @@
+final: prev:
+
+let
+  inherit (prev) system;
+  generic = import ./generic { inherit (prev) lib; pkgs = final; nixpkgs = prev.path; };
+  ubuntu = prev.callPackage ./ubuntu { inherit generic system; };
+  debian = prev.callPackage ./debian { inherit generic system; };
+  fedora = prev.callPackage ./fedora { inherit generic system; };
+in
+
+{
+  testers = prev.testers or { } // {
+    legacyDistros = {
+      inherit debian ubuntu fedora;
+    };
+  };
+}

--- a/tests/debian.nix
+++ b/tests/debian.nix
@@ -1,6 +1,6 @@
 { pkgs, package, system }:
 let
-  lib = package.${system};
+  lib = package;
   multiUserTest = runner: (runner {
     sharedDirs = {};
     testScript = ''
@@ -49,4 +49,4 @@ in {
   }).sandboxed;
 } //
 runTestOnEveryImage multiUserTest //
-package.${system}.debian.images
+package.debian.images

--- a/tests/fedora.nix
+++ b/tests/fedora.nix
@@ -1,6 +1,6 @@
 { pkgs, package, system }:
 let
-  lib = package.${system};
+  lib = package;
   multiUserTest = runner: (runner {
     sharedDirs = {};
     testScript = ''
@@ -49,4 +49,4 @@ in {
   }).sandboxed;
 } //
 runTestOnEveryImage multiUserTest //
-package.${system}.fedora.images
+package.fedora.images

--- a/tests/ubuntu.nix
+++ b/tests/ubuntu.nix
@@ -1,7 +1,7 @@
 { pkgs, package, system }:
 
 let
-  lib = package.${system};
+  lib = package;
   multiUserTest = runner: (runner {
     sharedDirs = {};
     testScript = ''
@@ -50,5 +50,5 @@ in {
   }).sandboxed;
 
 }
-// package.${system}.ubuntu.images
+// package.ubuntu.images
 // runTestOnEveryImage multiUserTest


### PR DESCRIPTION
This PR makes the library useable as an overlay.

~~It also enables aarch64 runs with flake-utils.
I did however not test aarch64 as i don't have a strong aarch64-linux system handy.~~

My intention to have an overlay is more of 

- being able to use this without flakes
- inside a flake that already uses overlays, just inject this one too instead of having it import nixpkgs another time

Please let me know what you think.