### PR TITLE
Overlay: legacyDistributions -> nix-vm-test namespace

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -59,7 +59,7 @@ Note: For a real-world deployment, you would probably want to pin `Nixpkgs` to a
 There is one last option to use this library: via a Nixpkgs overlay.
 
 The overlay function makes all linux distributions available under the attribute
-`pkgs.testers.legacyDistros...`:
+`pkgs.testers.nix-vm-test...`:
 
 ```nix
 {
@@ -78,7 +78,7 @@ The overlay function makes all linux distributions available under the attribute
        ];
      };
     in
-      packages.x86_64-linux.mytest = pkgs.testers.legacyDistros.debian."13" {
+      packages.x86_64-linux.mytest = pkgs.testers.nix-vm-test.debian."13" {
         sharedDirs.debDir = {
           source = "${./.}";
           target = "/mnt/debdir";

--- a/flake.nix
+++ b/flake.nix
@@ -14,10 +14,10 @@
       };
     in
     {
-      lib.${system} = pkgs.testers.legacyDistros;
+      lib.${system} = pkgs.testers.nix-vm-test;
 
       checks.${system} = import ./tests {
-        package = pkgs.testers.legacyDistros;
+        package = pkgs.testers.nix-vm-test;
         inherit pkgs system;
       };
 

--- a/overlay.nix
+++ b/overlay.nix
@@ -10,7 +10,7 @@ in
 
 {
   testers = prev.testers or { } // {
-    legacyDistros = {
+    nix-vm-test = {
       inherit debian ubuntu fedora;
     };
   };


### PR DESCRIPTION
Two reasons: I'm not super fan of the snark and this will likely be less confusing/prevent namespace clash.

@tfc FYI ^