### PR TITLE
Update Fedora images

### DIFF
--- a/fedora/images.json
+++ b/fedora/images.json
@@ -1,9 +1,5 @@
 {
   "x86_64-linux": {
-    "38": {
-      "name": "38/Cloud/x86_64/images/Fedora-Cloud-Base-38-1.6.x86_64.qcow2",
-      "hash": "sha256-0zRnBAH/PVtBKfzGYs9k9ablaCKK9ZB2zESaSUUxhII="
-    },
     "39": {
       "name": "39/Cloud/x86_64/images/Fedora-Cloud-Base-39-1.5.x86_64.qcow2",
       "hash": "sha256-q1vlBYxcg5Uop9Y3OTTgzlrWyPgL1x7TOQAyAn2lLzc="
@@ -11,7 +7,7 @@
     "40": {
       "name": "40/Cloud/x86_64/images/Fedora-Cloud-Base-Generic.x86_64-40-1.14.qcow2",
       "hash": "sha256-rFjzw1tzJy1ZhvptO8RP0ka0XfTDNOmaB7O70AaEre4="
-    }
+    },
     "41": {
       "name": "41/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2",
       "hash": "sha256-YgWuDFJLTRgW29NXPOKbXETtJsn7yHT75IxByJ3QusI="

--- a/fedora/images.json
+++ b/fedora/images.json
@@ -12,5 +12,9 @@
       "name": "40/Cloud/x86_64/images/Fedora-Cloud-Base-Generic.x86_64-40-1.14.qcow2",
       "hash": "sha256-rFjzw1tzJy1ZhvptO8RP0ka0XfTDNOmaB7O70AaEre4="
     }
+    "41": {
+      "name": "41/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2",
+      "hash": "sha256-YgWuDFJLTRgW29NXPOKbXETtJsn7yHT75IxByJ3QusI="
+    }
   }
 }

--- a/flake.lock
+++ b/flake.lock
@@ -1,22 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "id": "flake-utils",
-        "type": "indirect"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1708475490,
@@ -35,23 +18,7 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },


### PR DESCRIPTION
Current Fedora images are out of date PR removes 38 which is no longer available and add 41.