### PR TITLE
Fix test-driver output parsing crash on Ubuntu

### DIFF
--- a/tests/ubuntu.nix
+++ b/tests/ubuntu.nix
@@ -49,6 +49,14 @@ in {
     '';
   }).sandboxed;
 
+  sudoSameConsole = (lib.ubuntu."23_04" {
+    sharedDirs = {};
+    testScript = ''
+      # Ensure using sudo doesn't crash the test-driver
+      vm.execute("sudo bash -c \"echo 'Created foo → bar.\n' >&2 && echo 'foo' \"")
+    '';
+  }).sandboxed;
+
 }
 // package.ubuntu.images
 // runTestOnEveryImage multiUserTest

--- a/ubuntu/default.nix
+++ b/ubuntu/default.nix
@@ -57,6 +57,19 @@ let
           systemctl mask snapd.socket
           systemctl mask snapd.seeded.service
 
+          # Disable TTY usage in sudo.
+          # Otherwise, using sudo spawns a new pty, causing the test-driver to
+          # receive mixed stdout and stderr when processing command output.
+          # The driver only expects base64-encoded stdout, so extra stderr data
+          # can break the output parsing.
+          mkdir -p /etc/sudoers.d
+          cat << EOF > /etc/sudoers.d/disable-pty
+          Defaults !requiretty
+          Defaults !use_pty
+          EOF
+          visudo -cf /etc/sudoers.d/disable-pty
+          chmod 440 /etc/sudoers.d/disable-pty
+
           # We have no network in the test VMs, avoid an error on bootup
           systemctl mask ssh.service
           systemctl mask ssh.socket


### PR DESCRIPTION
When running tests on Ubuntu VMs, the `test-driver` can crash if the executed command calls `sudo` and writes to `stderr`. For example:

```python
vm.execute("sudo bash -c \"echo 'Created foo → bar.\n' >&2 && echo 'foo' \"")
```

`sudo` spawns a new TTY for `stderr` on Ubuntu that gets read by the `test-driver`'s output parsing. However, the `test-driver` only expects base64-encoded `stdout` and fails when `stderr` data is read.

- Normal command (note  `stderr` usees `/dev/ttyS0`)
```
> bash -c 'echo $$; ls -l /proc/$$/fd'
lr-x------ 1 root root 64 Feb 18 06:10 0 -> /dev/hvc0
l-wx------ 1 root root 64 Feb 18 06:10 1 -> pipe:[20942]
l-wx------ 1 root root 64 Feb 18 06:10 2 -> /dev/ttyS0
lr-x------ 1 root root 64 Feb 18 06:10 3 -> /proc/664/fd
```

- Using `sudo` (note `stderr` uses `/dev/pts/0`)
```
> sudo bash -c 'echo $$; ls -l /proc/$$/fd
lrwx------ 1 root root 64 Feb 18 06:10 0 -> /dev/pts/0
l-wx------ 1 root root 64 Feb 18 06:10 1 -> pipe:[20943]
lrwx------ 1 root root 64 Feb 18 06:10 2 -> /dev/pts/0
lr-x------ 1 root root 64 Feb 18 06:10 3 -> /proc/670/fd
```

Because `stderr` is now read along with the `stdout`, the `test-driver`'s base64 decoding code crashes on unexpected data:
- [encoding step](https://github.com/NixOS/nixpkgs/blob/8a24fbd0f3b4f47f01c897a95b1b65d6a5576c01/nixos/lib/test-driver/src/test_driver/machine.py#L578),
- [receiving the data](https://github.com/NixOS/nixpkgs/blob/8a24fbd0f3b4f47f01c897a95b1b65d6a5576c01/nixos/lib/test-driver/src/test_driver/machine.py#L515),
- [decoding step](https://github.com/NixOS/nixpkgs/blob/8a24fbd0f3b4f47f01c897a95b1b65d6a5576c01/nixos/lib/test-driver/src/test_driver/machine.py#L588).

A minimal reproducible example is provided in
[am-on/nix-test-driver-ubuntu-bug](https://github.com/am-on/nix-test-driver-ubuntu-bug).

Related issues:
- https://github.com/numtide/nix-vm-test/issues/84
- https://github.com/numtide/nix-vm-test/issues/5