### PR TITLE
make `sharedDirs` an optional attribute

### DIFF
--- a/debian/default.nix
+++ b/debian/default.nix
@@ -6,7 +6,7 @@ let
     url = image.name;
   };
   images = lib.mapAttrs (k: v: fetchImage v) imagesJSON.${system};
-  makeVmTestForImage = image: { testScript, sharedDirs, diskSize ? null }: generic.makeVmTest {
+  makeVmTestForImage = image: { testScript, sharedDirs ? {}, diskSize ? null }: generic.makeVmTest {
     inherit system testScript sharedDirs;
     image = prepareDebianImage {
       inherit diskSize;

--- a/fedora/default.nix
+++ b/fedora/default.nix
@@ -6,7 +6,7 @@ let
     url = "https://download.fedoraproject.org/pub/fedora/linux/releases/${image.name}";
   };
   images = lib.mapAttrs (k: v: fetchImage v) (imagesJSON.${system} or {});
-  makeVmTestForImage = image: { testScript, sharedDirs, diskSize ? null, extraPathsToRegister ? [ ]}: generic.makeVmTest {
+  makeVmTestForImage = image: { testScript, sharedDirs ? {}, diskSize ? null, extraPathsToRegister ? [ ]}: generic.makeVmTest {
     inherit system testScript sharedDirs;
     image = prepareFedoraImage {
       inherit diskSize extraPathsToRegister;

--- a/rocky/default.nix
+++ b/rocky/default.nix
@@ -6,7 +6,7 @@ let
     url = image.url;
   };
   images = lib.mapAttrs (k: v: fetchImage v) (imagesJSON.${system} or {});
-  makeVmTestForImage = image: { testScript, sharedDirs, diskSize ? null, extraPathsToRegister ? [ ]}: generic.makeVmTest {
+  makeVmTestForImage = image: { testScript, sharedDirs ? {}, diskSize ? null, extraPathsToRegister ? [ ]}: generic.makeVmTest {
     inherit system testScript sharedDirs;
     image = prepareRockyImage {
       inherit diskSize extraPathsToRegister;

--- a/ubuntu/default.nix
+++ b/ubuntu/default.nix
@@ -6,7 +6,7 @@ let
     url = image.name;
   };
   images = lib.mapAttrs (k: v: fetchImage v) imagesJSON.${system};
-  makeVmTestForImage = image: { testScript, sharedDirs, diskSize ? null, extraPathsToRegister ? [ ] }: generic.makeVmTest {
+  makeVmTestForImage = image: { testScript, sharedDirs ? {}, diskSize ? null, extraPathsToRegister ? [ ] }: generic.makeVmTest {
     inherit system testScript sharedDirs;
     image = prepareUbuntuImage {
       inherit diskSize extraPathsToRegister;


### PR DESCRIPTION
All checks pass with `nix flake check` on my `x86_64-linux` work machine.