### PR TITLE
fix repository locking for rocky linux

### DIFF
--- a/rocky/default.nix
+++ b/rocky/default.nix
@@ -113,7 +113,7 @@ let
             sed -i 's@$contentdir@vault/rocky@g' "''${repoFile}"
 
             # all this to not pollute the current environment with $VERSION_ID
-            /bin/bash -c 'export $(cat /etc/os-release | grep '^VERSION_ID=') && sed -i "s@\$releasever@''${VERSION_ID}@g"' "''${repoFile}"
+            (export $(cat /etc/os-release | grep '^VERSION_ID=' | sed -e 's/"//g') && sed -i "s@\$releasever@''${VERSION_ID}@g" "''${repoFile}")
           done
           # change the value of the `contentdir` DNF variable
           [ -f /etc/dnf/vars/contentdir ] && sed -i 's@pub/rocky@vault/rocky@g' /etc/dnf/vars/contentdir


### PR DESCRIPTION
I had mistakenly pushed an incorrect branch that contained the typo. This commit rebases my merged changes and switches from `bash -c` to a sub-shell for flexibility with single quotes.

One can verify that the repository is always reachable by cleaning the DNF cache with `dnf clean expire-cache` and then performing a repository check with `dnf repocheck`. And, I would love to add a test under `./tests/` but because `dnf repocheck` requires a connection to the wider internet, this would always fail in a Nix sandbox. Hence, no tests to catch this particular error. Sorry!