### PR TITLE
ubuntu: respect `diskSize`

### DIFF
--- a/ubuntu/default.nix
+++ b/ubuntu/default.nix
@@ -32,7 +32,7 @@ let
 
       ${lib.optionalString (diskSize != null) ''
         export PATH="${pkgs.qemu}/bin:$PATH"
-        qemu-img resize ${resultImg} +2G
+        qemu-img resize ${resultImg} ${diskSize}
       ''}
 
       #export LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1


### PR DESCRIPTION
Currently Ubuntu is hardcoded to `+2G` rather than respecting `diskSize` like all the other distros:

https://github.com/numtide/nix-vm-test/blob/ebfa47638075f46862567e337ccf19d66cd59bea/debian/default.nix#L35-L38
https://github.com/numtide/nix-vm-test/blob/ebfa47638075f46862567e337ccf19d66cd59bea/fedora/default.nix#L51-L54
https://github.com/numtide/nix-vm-test/blob/ebfa47638075f46862567e337ccf19d66cd59bea/rocky/default.nix#L53-L56