### PR TITLE
Update nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1766309749,
-        "narHash": "sha256-3xY8CZ4rSnQ0NqGhMKAy5vgC+2IVK0NoVEzDoOh4DA4=",
+        "lastModified": 1775423009,
+        "narHash": "sha256-vPKLpjhIVWdDrfiUM8atW6YkIggCEKdSAlJPzzhkQlw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a6531044f6d0bef691ea18d4d4ce44d0daa6e816",
+        "rev": "68d8aa3d661f0e6bd5862291b5bb263b2a6595c9",
         "type": "github"
       },
       "original": {

--- a/generic/default.nix
+++ b/generic/default.nix
@@ -142,6 +142,7 @@ ${lib.optionalString (pathsToRegister != []) ''
         ];
       }).config;
 
+      nodeNames = lib.attrNames config.nodes;
       nodes = interactive: map (runVmScript interactive) (lib.attrValues config.nodes);
 
       runVmScript = interactive: node:
@@ -213,9 +214,12 @@ ${lib.optionalString (pathsToRegister != []) ''
         # Exporting the current directory. The start script need it to
         # resolve the relative mount points.
         export rundir="$(pwd)"
+        export containerNames=""
+        export containerStartScripts=""
         ${lib.getBin test-driver}/bin/nixos-test-driver \
         ${lib.optionalString interactive "--interactive"} \
-        --start-scripts ${lib.concatStringsSep " " (nodes interactive)} \
+        --vm-names ${lib.concatStringsSep " " nodeNames} \
+          --vm-start-scripts ${lib.concatStringsSep " " (nodes interactive)} \
           --vlans ${lib.concatStringsSep " " vlans} \
           -- ${hostPkgs.writeText "test-script" testScriptWithMounts}
       '';


### PR DESCRIPTION
Update nixpkgs and the nixos-test-driver CLI which renamed --start-scripts to --vm-start-scripts and now requires --vm-names to be provided.