### PR TITLE
images: add Fedora 42 and Rocky 10.1 cloud images

### DIFF
--- a/fedora/images.json
+++ b/fedora/images.json
@@ -11,6 +11,16 @@
     "41": {
       "name": "41/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2",
       "hash": "sha256-YgWuDFJLTRgW29NXPOKbXETtJsn7yHT75IxByJ3QusI="
+    },
+    "42": {
+      "name": "42/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-42-1.1.x86_64.qcow2",
+      "hash": "sha256-5AGk2y5eBNGWe2cpd0+qltpim887qQtn2NnM6ZBr7A8="
+    }
+  },
+  "aarch64-linux": {
+    "42": {
+      "name": "42/Cloud/aarch64/images/Fedora-Cloud-Base-Generic-42-1.1.aarch64.qcow2",
+      "hash": "sha256-4QZYQZqNUCMQN9x4HDFVqpQYCox6dOXKwqawnqqTQrc="
     }
   }
 }

--- a/rocky/images.json
+++ b/rocky/images.json
@@ -55,6 +55,11 @@
       "url": "https://download.rockylinux.org/vault/rocky/9.6/images/aarch64/Rocky-9-GenericCloud-Base-9.6-20250531.0.aarch64.qcow2",
       "name": "Rocky-9.6-GenericCloud.aarch64.qcow2",
       "sha256": "0jhfnggfp5ywbqmxz1cb9lhvxlm8zffw8h5l5a7c44f0gk0v4xip"
+    },
+    "10_1": {
+      "url": "https://download.rockylinux.org/pub/rocky/10.1/images/aarch64/Rocky-10-GenericCloud-Base-10.1-20251116.0.aarch64.qcow2",
+      "name": "Rocky-10.1-GenericCloud.aarch64.qcow2",
+      "sha256": "0vg3ir1ishq9581rpmzl2c6vlm62kfkkb9wg2cr5ahgvz0y05h5b"
     }
   },
 
@@ -114,6 +119,11 @@
       "url": "https://download.rockylinux.org/vault/rocky/9.6/images/x86_64/Rocky-9-GenericCloud-Base-9.6-20250531.0.x86_64.qcow2",
       "name": "Rocky-9.6-GenericCloud.x86_64.qcow2",
       "sha256": "0g8ad60a62hk0bxw6icavci3f0sjkc77h127vszcrb9wp1dq2wic"
+    },
+    "10_1": {
+      "url": "https://download.rockylinux.org/pub/rocky/10.1/images/x86_64/Rocky-10-GenericCloud-Base-10.1-20251116.0.x86_64.qcow2",
+      "name": "Rocky-10.1-GenericCloud.x86_64.qcow2",
+      "sha256": "1ba7qdmnvmkc5jp998kdka8ib1w9yb1wmjzcw7wwcd5112zqlqi8"
     }
   }
 }


### PR DESCRIPTION
Closes #170 

Just adding Rocky 10.1 and Fedora 42 targets.  ^w^

🍻