### PR TITLE
fix: configure test-driver using new json configuration file

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775423009,
-        "narHash": "sha256-vPKLpjhIVWdDrfiUM8atW6YkIggCEKdSAlJPzzhkQlw=",
+        "lastModified": 1776877367,
+        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "68d8aa3d661f0e6bd5862291b5bb263b2a6595c9",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
         "type": "github"
       },
       "original": {

--- a/generic/default.nix
+++ b/generic/default.nix
@@ -138,8 +138,9 @@ rec {
         ];
       }).config;
 
-      nodeNames = lib.attrNames config.nodes;
-      nodes = interactive: map (runVmScript interactive) (lib.attrValues config.nodes);
+      nodes = interactive: lib.mapAttrs
+        (name: node: { inherit name; start_script = runVmScript interactive node; })
+        config.nodes;
 
       runVmScript = interactive: node:
       let
@@ -206,23 +207,30 @@ rec {
 
       test-driver = hostPkgs.python3Packages.callPackage "${nixpkgs}/nixos/lib/test-driver" { };
 
-      runTest = { nodes, vlans, interactive }: ''
+      # create configuration file based on test driver configuration
+      # see https://github.com/NixOS/nixpkgs/blob/6ab8a6fd46fa56298ad16ec9b36cf6ab04413459/nixos/lib/test-driver/src/test_driver/driver.py#L38
+      driverConfigFile = { vlans, interactive }:
+        hostPkgs.writers.writeJSON "driver-configuration.json" {
+          vms = nodes interactive;
+          containers = { };
+          inherit vlans;
+          global_timeout = 60 * 60;
+          enable_ssh_backdoor = false;
+          test_script = hostPkgs.writeText "test-script" testScriptWithMounts;
+        };
+
+      runTest = { vlans, interactive }: ''
         # Exporting the current directory. The start script need it to
         # resolve the relative mount points.
         export rundir="$(pwd)"
-        export containerNames=""
-        export containerStartScripts=""
         ${lib.getBin test-driver}/bin/nixos-test-driver \
-        ${lib.optionalString interactive "--interactive"} \
-        --vm-names ${lib.concatStringsSep " " nodeNames} \
-          --vm-start-scripts ${lib.concatStringsSep " " (nodes interactive)} \
-          --vlans ${lib.concatStringsSep " " vlans} \
-          -- ${hostPkgs.writeText "test-script" testScriptWithMounts}
+          ${lib.optionalString interactive "--interactive"} \
+          -c ${driverConfigFile { inherit vlans interactive; }}
       '';
 
       defaultTest = { interactive ? false }: runTest {
-        inherit interactive nodes;
-        vlans = [ "1" ];
+        inherit interactive;
+        vlans = [ 1 ];
       };
 
       targets =


### PR DESCRIPTION
Since https://github.com/NixOS/nixpkgs/pull/510385, the test-driver expects a json configuration file instead of command line arguments.

This change creates the json configuration file and updates the test-driver invocation to use it.