### PR TITLE
feat: support running on darwin

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ And run your tests using a single CLI command.
 
 This project builds on the [NixOS VM test](https://nixos.org/manual/nixos/stable/#sec-nixos-tests) infrastructure to allow you to test your software instantly on Ubuntu, Debian, Fedora, and Rocky virtual machines.
 
-It runs on any Linux machine with Nix installed.
+It runs on any Linux machine with Nix installed, and on Apple Silicon (aarch64)
+macOS with a Linux builder configured (see [Prerequisites](#prerequisites)).
 
 Your tests can either be used:
 
@@ -45,11 +46,17 @@ You configure **nix-vm-test** using Nix package manager, either in a flake or in
 
 ## Prerequisites
 
-- A Linux machine
-
 - Nix Package Manager
 
-- Hardware KVM acceleration. The project will run without it, but it will be too slow for practical purposes.
+- Either:
+  - **Linux**: any `x86_64-linux` or `aarch64-linux` machine, with hardware **KVM**
+    acceleration (`/dev/kvm`). The project will run without it, but it will be too
+    slow for practical purposes.
+  - **macOS**: Apple Silicon (`aarch64-darwin`), with a **Linux builder** — nix-darwin's
+    [`linux-builder`](https://nix-darwin.github.io/nix-darwin/manual/index.html#opt-nix.linux-builder.enable)
+    or a remote `aarch64-linux` build machine. This is **required**: the guest
+    image is customized in a Linux derivation that is not available from any binary
+    cache and therefore must be built. VMs run as `aarch64-linux` guests.
 
 -----
 

--- a/debian/default.nix
+++ b/debian/default.nix
@@ -1,23 +1,68 @@
-{ generic, pkgs, lib, system }:
+{ generic, guestPkgs, lib, guestSystem }:
 let
   imagesJSON = lib.importJSON ./images.json;
-  fetchImage = image: pkgs.fetchurl {
+  fetchImage = image: guestPkgs.fetchurl {
     sha256 = image.hash;
     url = image.name;
   };
-  images = lib.mapAttrs (k: v: fetchImage v) imagesJSON.${system};
-  makeVmTestForImage = imageID: image: { testScript, sharedDirs ? {}, diskSize ? null, extraPathsToRegister ? [ ], memorySize ? null, cpus ? null }: generic.makeVmTest {
+  images = lib.mapAttrs (k: v: fetchImage v) (imagesJSON.${guestSystem} or {});
+
+  # aarch64 has no guestfs; customize via a cloud-init seed at boot instead (see ubuntu).
+  useCloudInit = generic.guestIsAarch64;
+
+  # Grow the raw cloud image (guestfs-free) when a diskSize is requested. cloud-init's
+  # default `growpart`/`resizefs` modules then grow the partition/filesystem on boot
+  # (unlike the baked path, cloud-init is still active here, so a custom resize
+  # service would just race it and fail with "NOCHANGE: ... it cannot be grown").
+  resizeRawImage = { originalImage, diskSize }:
+    if diskSize == null then originalImage
+    else guestPkgs.runCommand "${originalImage.name}-resized.qcow2"
+      { nativeBuildInputs = [ guestPkgs.qemu ]; } ''
+        install -m644 ${originalImage} "$out"
+        qemu-img resize "$out" ${diskSize}
+      '';
+
+  debianCloudInitSeed = { extraPathsToRegister }:
+    generic.mkCloudInitSeed {
+      files = {
+        "backdoor.service" = generic.backdoor { };
+        "mount-store.service" = generic.mountStore { pathsToRegister = extraPathsToRegister; };
+      };
+      userData = generic.mkUserData {
+        runcmd = [
+          "mkdir -p /run/nixvmtest-seed"
+          "mount -o ro /dev/disk/by-label/CIDATA /run/nixvmtest-seed"
+          "install -m644 /run/nixvmtest-seed/backdoor.service /etc/systemd/system/backdoor.service"
+          "install -m644 /run/nixvmtest-seed/mount-store.service /etc/systemd/system/mount-store.service"
+          "umount /run/nixvmtest-seed"
+          "passwd -d root"
+          "systemctl mask --now serial-getty@${generic.serialConsole}.service serial-getty@hvc0.service"
+          "systemctl mask ssh.service ssh.socket"
+          "systemctl daemon-reload"
+          # Start only the backdoor; its Requires/After pulls mount-store in once
+          # (see ubuntu/default.nix for why activating mount-store separately breaks).
+          "systemctl start backdoor.service"
+        ];
+      };
+    };
+
+  makeVmTestForImage = imageID: image: { testScript, sharedDirs ? {}, diskSize ? null, extraPathsToRegister ? [ ], memorySize ? null, cpus ? null }: generic.makeVmTest ({
     name = "vm-test-debian_${imageID}";
-    inherit system testScript sharedDirs memorySize cpus;
+    inherit testScript sharedDirs memorySize cpus;
+  } // (if useCloudInit then {
+    image = resizeRawImage { originalImage = image; inherit diskSize; };
+    cloudInitSeed = debianCloudInitSeed { inherit extraPathsToRegister; };
+  } else {
     image = prepareDebianImage {
       inherit diskSize extraPathsToRegister;
-      hostPkgs = pkgs;
+      # Image preparation is Linux work, so it always runs with `guestPkgs`.
+      buildPkgs = guestPkgs;
       originalImage = image;
     };
-  };
-  prepareDebianImage = { hostPkgs, originalImage, diskSize, extraPathsToRegister ? [ ]}:
+  }));
+  prepareDebianImage = { buildPkgs, originalImage, diskSize, extraPathsToRegister ? [ ]}:
     let
-      pkgs = hostPkgs;
+      pkgs = buildPkgs;
       resultImg = "./image.qcow2";
     in
     pkgs.runCommand "${originalImage.name}-nix-vm-test.qcow2" { } ''
@@ -53,7 +98,7 @@ let
           passwd -d root
 
           # Don't spawn ttys on these devices, they are used for test instrumentation
-          systemctl mask serial-getty@ttyS0.service
+          systemctl mask serial-getty@${generic.serialConsole}.service
           systemctl mask serial-getty@hvc0.service
 
           # We have no network in the test VMs, avoid an error on bootup

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -103,7 +103,21 @@ $ROOT.$DISTRIBUTION {
 }
 ```
 
-Where `$ROOT` will be `nix-vm-test.lib.x86_64-linux` on a flake-based setup.
+Where `$ROOT` will be `nix-vm-test.lib.<system>` on a flake-based setup.
+
+### Platform support
+
+`<system>` is the **host** system running the driver. Supported hosts:
+
+| Host system      | Guest system    | Acceleration | Notes                                  |
+| ---------------- | --------------- | ------------ | -------------------------------------- |
+| `x86_64-linux`   | `x86_64-linux`  | KVM          |                                        |
+| `aarch64-linux`  | `aarch64-linux` | KVM          |                                        |
+| `aarch64-darwin` | `aarch64-linux` | HVF          | Requires a Linux builder (see README). |
+
+On macOS the VMs run as `aarch64-linux` guests, so only distributions that publish
+an `aarch64` image are available there (**Fedora is x86_64-only and is therefore not
+exposed yet on `aarch64-darwin`**).
 
 Where `$DISTRIBUTION` is a `$NAME.$VERSION` couple. Here's the currently supported name/version couples:
 

--- a/fedora/default.nix
+++ b/fedora/default.nix
@@ -1,22 +1,25 @@
-{ generic, pkgs, lib, system }:
+{ generic, guestPkgs, lib, guestSystem }:
 let
   imagesJSON = lib.importJSON ./images.json;
-  fetchImage = image: pkgs.fetchurl {
+  fetchImage = image: guestPkgs.fetchurl {
     inherit (image) hash;
     url = "https://download.fedoraproject.org/pub/fedora/linux/releases/${image.name}";
   };
-  images = lib.mapAttrs (k: v: fetchImage v) (imagesJSON.${system} or {});
+  # Fedora only ships x86_64 images here, so on an aarch64 guest (e.g. darwin)
+  # `imagesJSON.${guestSystem}` is absent and this cleanly resolves to no tests.
+  images = lib.mapAttrs (k: v: fetchImage v) (imagesJSON.${guestSystem} or {});
   makeVmTestForImage = imageID: image: { testScript, sharedDirs ? {}, diskSize ? null, extraPathsToRegister ? [ ], selinuxEnforcing ? false, memorySize ? null, cpus ? null }: generic.makeVmTest {
     name = "vm-test-fedora_${imageID}";
-    inherit system testScript sharedDirs memorySize cpus;
+    inherit testScript sharedDirs memorySize cpus;
     image = prepareFedoraImage {
       inherit diskSize extraPathsToRegister selinuxEnforcing;
-      hostPkgs = pkgs;
+      # Image preparation is Linux work, so it always runs with `guestPkgs`.
+      buildPkgs = guestPkgs;
       originalImage = image;
     };
   };
 
-  resizeService = pkgs.writeText "resizeService" ''
+  resizeService = guestPkgs.writeText "resizeService" ''
     [Service]
     Type = oneshot
     ExecStart = growpart /dev/sda 5
@@ -26,9 +29,9 @@ let
     WantedBy = multi-user.target
   '';
 
-  prepareFedoraImage = { hostPkgs, originalImage, diskSize, extraPathsToRegister, selinuxEnforcing ? false }:
+  prepareFedoraImage = { buildPkgs, originalImage, diskSize, extraPathsToRegister, selinuxEnforcing ? false }:
     let
-      pkgs = hostPkgs;
+      pkgs = buildPkgs;
       resultImg = "./image.qcow2";
     in
     pkgs.runCommand "${originalImage.name}-nix-vm-test.qcow2" { } ''
@@ -72,7 +75,7 @@ let
           groupadd nixbld
 
           # Don't spawn ttys on these devices, they are used for test instrumentation
-          systemctl mask serial-getty@ttyS0.service
+          systemctl mask serial-getty@${generic.serialConsole}.service
           systemctl mask serial-getty@hvc0.service
 
           # We have no network in the test VMs, avoid an error on bootup

--- a/flake.nix
+++ b/flake.nix
@@ -7,19 +7,34 @@
 
   outputs = { self, nixpkgs }:
     let
-      system = "x86_64-linux";
-      pkgs = import nixpkgs {
+      inherit (nixpkgs) lib;
+
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
+      forAllSystems = f: lib.genAttrs supportedSystems f;
+      guestSystemFor = import ./systems.nix;
+
+      pkgsFor = system: import nixpkgs {
         overlays = [ self.overlays.default ];
         localSystem = system;
       };
+      # Reuse the host's own evaluation when the guest matches it (the common,
+      # non-darwin case), instead of importing nixpkgs a second time from scratch.
+      guestPkgsFor = system:
+        let guestSystem = guestSystemFor system;
+        in if guestSystem == system
+          then pkgsFor system
+          else import nixpkgs { localSystem = guestSystem; };
     in
     {
-      lib.${system} = pkgs.testers.nonNixOSDistros;
+      lib = forAllSystems (system: (pkgsFor system).testers.nonNixOSDistros);
 
-      checks.${system} = import ./tests {
-        package = pkgs.testers.nonNixOSDistros;
-        inherit pkgs system;
-      };
+      checks = forAllSystems (system:
+        import ./tests {
+          package = (pkgsFor system).testers.nonNixOSDistros;
+          pkgs = pkgsFor system;
+          guestPkgs = guestPkgsFor system;
+          inherit system;
+        });
 
       overlays.default = import ./overlay.nix;
     };

--- a/generic/default.nix
+++ b/generic/default.nix
@@ -1,5 +1,17 @@
-{ lib, pkgs, nixpkgs }:
+{ lib, hostPkgs, guestPkgs, nixpkgs, ... }:
 rec {
+  # `hostPkgs`  : packages that run on the machine driving the test (QEMU, the
+  #               Python test-driver, the run-vm wrapper script). On a Linux host
+  #               this is the same as `guestPkgs`; on darwin it is a darwin set.
+  # `guestPkgs` : packages that run *inside* the Linux guest or are baked into the
+  #               image (backdoor shell, `nix-store`, image preparation). These must
+  #               always be Linux packages, so on darwin they are built for the
+  #               matching `*-linux` system (via a Linux/remote builder).
+  qemuArch = guestPkgs.stdenv.hostPlatform.qemuArch;
+  guestIsAarch64 = guestPkgs.stdenv.hostPlatform.isAarch64;
+  hostIsDarwin = hostPkgs.stdenv.hostPlatform.isDarwin;
+  serialConsole = if guestIsAarch64 then "ttyAMA0" else "ttyS0";
+
   defaultMachineConfigModule = { ... }: {
     nodes = {
     };
@@ -7,13 +19,13 @@ rec {
   printAttrPos = { file, line, column }: "${file}:${toString line}:${toString column}";
 
   # Careful since we do not have the nix store yet when this service runs,
-  # so we cannot use pkgs.writeText or pkgs.writeShellScript for instance,
+  # so we cannot use guestPkgs.writeText or guestPkgs.writeShellScript for instance,
   # since their results would refer to the store
   mountStore = { pathsToRegister ? [ ] }:
     let
-      pathRegistrationInfo = "${pkgs.closureInfo { rootPaths = pathsToRegister; }}/registration";
+      pathRegistrationInfo = "${guestPkgs.closureInfo { rootPaths = pathsToRegister; }}/registration";
     in
-    pkgs.writeText "mount-store.service" ''
+    guestPkgs.writeText "mount-store.service" ''
       [Service]
       Type = oneshot
       User = root
@@ -23,12 +35,12 @@ rec {
         mkdir -p -m 0755 /nix/.rw-store/ /nix/store; \
         mount -t tmpfs -o size=2G tmpfs /nix/.rw-store; \
         mkdir -p -m 0755 /nix/.rw-store/store /nix/.rw-store/work; \
-        mount -t overlay overlay /nix/store -o lowerdir=/nix/.ro-store,upperdir=/nix/.rw-store/store,workdir=/nix/.rw-store/work${lib.optionalString (pathsToRegister != []) "; ${lib.getBin pkgs.nix}/bin/nix-store --load-db < ${pathRegistrationInfo}"}'
+        mount -t overlay overlay /nix/store -o lowerdir=/nix/.ro-store,upperdir=/nix/.rw-store/store,workdir=/nix/.rw-store/work${lib.optionalString (pathsToRegister != []) "; ${lib.getBin guestPkgs.nix}/bin/nix-store --load-db < ${pathRegistrationInfo}"}'
       [Install]
       WantedBy = multi-user.target
     '';
 
-  backdoorScript = pkgs.writeShellScript "backdoor-start-script" ''
+  backdoorScript = guestPkgs.writeShellScript "backdoor-start-script" ''
     set -euo pipefail
 
     ProtectSystem=false
@@ -48,7 +60,7 @@ rec {
 
     cd /tmp
     exec < /dev/hvc0 > /dev/hvc0
-    while ! exec 2> /dev/ttyS0; do sleep 0.1; done
+    while ! exec 2> /dev/${serialConsole}; do sleep 0.1; done
     echo "connecting to host..." >&2
     stty -F /dev/hvc0 raw -echo # prevent nl -> cr/nl conversion
     # This line is essential since it signals to the test driver that the
@@ -70,10 +82,10 @@ rec {
   #               the backdoor script changes, allow the "builder"
   #               to specify it
   backdoor = { withMountedStore ? true, scriptPath ? backdoorScript }:
-    pkgs.writeText "backdoor.service" ''
+    guestPkgs.writeText "backdoor.service" ''
       [Unit]
-      Requires = dev-hvc0.device dev-ttyS0.device ${lib.strings.optionalString withMountedStore "mount-store.service"}
-      After = dev-hvc0.device dev-ttyS0.device ${lib.strings.optionalString withMountedStore "mount-store.service"}
+      Requires = dev-hvc0.device dev-${serialConsole}.device ${lib.strings.optionalString withMountedStore "mount-store.service"}
+      After = dev-hvc0.device dev-${serialConsole}.device ${lib.strings.optionalString withMountedStore "mount-store.service"}
       # Keep this unit active when we switch to rescue mode for instance
       IgnoreOnIsolate = true
 
@@ -85,7 +97,9 @@ rec {
       WantedBy = multi-user.target
     '';
 
-    resizeService = pkgs.writeText "resizeService" ''
+    # Baked (x86_64) path only: the aarch64/cloud-init path relies on cloud-init's
+    # own default growpart/resizefs modules instead (see ubuntu/default.nix).
+    resizeService = guestPkgs.writeText "resizeService" ''
       [Service]
       Type = oneshot
       ExecStart = apt-get install -yq cloud-guest-utils
@@ -96,20 +110,56 @@ rec {
       WantedBy = multi-user.target
     '';
 
+  # Build a cloud-init NoCloud seed ISO. Used on darwin/aarch64 where `guestfs`
+  # (and therefore `virt-customize`) is unavailable: instead of baking the guest
+  # customization into the image ahead of time, we attach this seed at VM launch
+  # and let cloud-init apply it on boot.
+  #
+  # `files`    : attrset of `<name-on-seed> = <store path>`; copied verbatim onto
+  #              the seed so `runcmd` can install them into the guest.
+  # `userData` : the cloud-config (`#cloud-config …`) YAML string.
+  #
+  # The seed is a plain ISO9660 volume labelled CIDATA, which cloud-init's NoCloud
+  # datasource discovers automatically on any attached block device.
+  mkCloudInitSeed = { files ? { }, userData }:
+    guestPkgs.runCommand "cloud-init-seed.iso"
+      { nativeBuildInputs = [ guestPkgs.cdrkit ]; }
+      ''
+        mkdir -p seed
+        printf 'instance-id: iid-nixvmtest\nlocal-hostname: vm\n' > seed/meta-data
+        cp ${guestPkgs.writeText "user-data" userData} seed/user-data
+        ${lib.concatStrings (lib.mapAttrsToList (name: src: "cp ${src} seed/${name}\n") files)}
+        ( cd seed && genisoimage -output "$out" -volid CIDATA -joliet -rock * )
+      '';
+
+  # Assemble a `#cloud-config` user-data document. `runcmd` is a list of shell
+  # command strings run (in order, as root) on boot. Guest customization files are
+  # shipped on the seed (see `mkCloudInitSeed`'s `files`) and installed by `runcmd`,
+  # which keeps this pure (no import-from-derivation of file contents).
+  # Each command is emitted via `builtins.toJSON` (a valid YAML double-quoted
+  # scalar) rather than as a raw plain scalar, so a command containing a
+  # leading '#' or ': ' can't be misparsed as a YAML comment/mapping.
+  mkUserData = { runcmd ? [ ] }:
+    lib.concatStringsSep "\n" (
+      [ "#cloud-config" ]
+      ++ lib.optionals (runcmd != [ ]) ([ "runcmd:" ] ++ map (c: "  - ${builtins.toJSON c}") runcmd)
+    );
+
   makeVmTest =
-    { system
-    , image
+    { image
     , testScript
     , sharedDirs
     , machineConfigModule ? defaultMachineConfigModule
     , memorySize ? null
     , cpus ? null
     , name ? "vm-test"
+    # Optional cloud-init NoCloud seed ISO (see `mkCloudInitSeed`). When set, it is
+    # attached as an extra drive so cloud-init customizes the guest on boot. Used
+    # on darwin/aarch64 in place of the baked `virt-customize` image.
+    , cloudInitSeed ? null
     }:
     let
-      hostPkgs = pkgs;
-
-      mountSharesScript = pkgs.writeScriptBin "mount-shares" {} ''
+      mountSharesScript = hostPkgs.writeScriptBin "mount-shares" {} ''
       '';
 
       # TODO: hacky hacky… We need to mount the 9p shares at some
@@ -152,6 +202,50 @@ rec {
       runVmScript = interactive: node:
       let
         qemupkg = (if !interactive then hostPkgs.qemu_test else hostPkgs.qemu);
+
+        # On darwin we accelerate with Apple's Hypervisor.framework (HVF); on Linux
+        # with KVM. We only ever pair a host with a same-architecture Linux guest
+        # (e.g. aarch64-darwin → aarch64-linux), so hardware acceleration always applies.
+        accel = if hostIsDarwin then "hvf" else "kvm";
+
+        qemuBinary = "${lib.getBin qemupkg}/bin/qemu-system-${qemuArch}";
+
+        machineFlags =
+          if guestIsAarch64 then
+            [ "-machine virt,accel=${accel}" ]
+          else
+            [ "-machine accel=${accel}" ];
+
+        firmwareFlags = lib.optionals guestIsAarch64 [
+          "-drive if=pflash,format=raw,unit=0,readonly=on,file=${qemupkg}/share/qemu/edk2-aarch64-code.fd"
+          "-drive if=pflash,format=raw,unit=1,file=\"$TMPDIR/efivars.fd\""
+        ];
+
+        diskFlags =
+          if guestIsAarch64 then
+            [ "-drive if=none,file=${image},format=qcow2,id=disk0"
+              "-device virtio-blk-pci,drive=disk0"
+            ]
+          else
+            [ "-drive file=${image},format=qcow2" ];
+
+        # Attach the cloud-init NoCloud seed (read-only) when provided.
+        seedFlags = lib.optionals (cloudInitSeed != null) [
+          "-drive if=none,id=cidata,format=raw,readonly=on,file=${cloudInitSeed}"
+          "-device virtio-blk-pci,drive=cidata"
+        ];
+
+        # On aarch64 UEFI, disable the NIC's option ROM via romfile=. Without this,
+        # every boot prints "Image type X64 can't be loaded on AARCH64 UEFI system."
+        # while EDK2 tries (and fails) to load the ROM's x86 EFI section — harmless
+        # (the disk still boots normally) but noisy on every single boot. We never
+        # PXE-boot, so dropping the ROM outright is safe and removes the warning.
+        netDevFlag =
+          if guestIsAarch64 then
+            "-device virtio-net-pci,netdev=net0,romfile="
+          else
+            "-device virtio-net-pci,netdev=net0";
+
         # The test driver extracts the name of the node from the name of the
         # VM script, so it's important here to stick to the naming scheme expected
         # by the test driver.
@@ -185,20 +279,23 @@ rec {
           mkdir -p "$TMPDIR/xchg"
 
           cd "$TMPDIR"
+          ${lib.optionalString guestIsAarch64 ''
+            # Writable UEFI variable store for the aarch64 firmware above. A blank
+            # 64 MiB NVRAM matches the code image size; -snapshot keeps it ephemeral.
+            truncate -s 64M "$TMPDIR/efivars.fd"
+          ''}
 
           # Start QEMU.
-          # We might need to be smarter about the QEMU binary to run when we want to
-          # support architectures other than x86_64.
-          # See qemu-common.nix in nixpkgs.
-          ${lib.concatStringsSep "\\\n  " [
-            "exec ${lib.getBin qemupkg}/bin/qemu-kvm"
+          ${lib.concatStringsSep "\\\n  " ([
+            "exec ${qemuBinary}"
+          ] ++ machineFlags ++ [
             "-device virtio-rng-pci"
             "-cpu max"
             "-name vm"
             "-m ${toString node.virtualisation.memorySize}"
             "-smp ${toString node.virtualisation.cpus}"
-            "-drive file=${image},format=qcow2"
-            "-device virtio-net-pci,netdev=net0"
+          ] ++ firmwareFlags ++ diskFlags ++ seedFlags ++ [
+            netDevFlag
             "-netdev user,id=net0"
             "-virtfs local,security_model=passthrough,id=fsdev1,path=/nix/store,readonly=on,mount_tag=nix-store"
             (lib.concatStringsSep "\\\n  "
@@ -209,10 +306,27 @@ rec {
             (lib.optionalString (!interactive) "-nographic")
             "$QEMU_OPTS"
             "$@"
-          ]};
+          ])};
         '';
 
-      test-driver = hostPkgs.python3Packages.callPackage "${nixpkgs}/nixos/lib/test-driver" { };
+      test-driver =
+        (hostPkgs.python3Packages.callPackage "${nixpkgs}/nixos/lib/test-driver"
+          # `vhost-device-vsock` is a Linux-only dependency of the test driver (used
+          # for the vsock SSH backdoor). We never enable that backdoor
+          # (`enable_ssh_backdoor = false`), so on darwin we swap it for a harmless
+          # stand-in to keep the driver evaluatable. On Linux the real dep is used.
+          (lib.optionalAttrs hostIsDarwin {
+            vhost-device-vsock = hostPkgs.emptyDirectory;
+          })
+        ).overrideAttrs (old: {
+          # `vlan.py`'s `_log_stream` forwards the vde_switch / vde_plug2tap pipes to
+          # `logger.debug()` but decodes them as STRICT UTF-8.
+          postPatch = (old.postPatch or "") + ''
+            vlan=$(find . -path '*test_driver/vlan.py' | head -n1)
+            substituteInPlace "$vlan" \
+              --replace-fail ${lib.escapeShellArg "text=True,"} ${lib.escapeShellArg "text=True,\n            errors=\"replace\","}
+          '';
+        });
 
       # create configuration file based on test driver configuration
       # see https://github.com/NixOS/nixpkgs/blob/6ab8a6fd46fa56298ad16ec9b36cf6ab04413459/nixos/lib/test-driver/src/test_driver/driver.py#L38
@@ -246,7 +360,10 @@ rec {
         in
         {
           sandboxed = hostPkgs.stdenv.mkDerivation {
-            requiredSystemFeatures = [ "kvm" "nixos-test" ];
+            # KVM on Linux, Apple's Hypervisor.framework on darwin.
+            requiredSystemFeatures = [ "nixos-test" ]
+              ++ lib.optional hostIsDarwin "apple-virt"
+              ++ lib.optional (!hostIsDarwin) "kvm";
             buildCommand = ''
               ${defaultTest {}}
               touch $out

--- a/lib.nix
+++ b/lib.nix
@@ -1,14 +1,27 @@
 { nixpkgs,   # The nixpkgs source
-  system
+  system     # The *host* system (where QEMU and the test driver run)
 }:
 let
-  pkgs = import nixpkgs { inherit system; };
   inherit (nixpkgs) lib;
-  generic = pkgs.callPackage ./generic { inherit nixpkgs; };
-  ubuntu = pkgs.callPackage ./ubuntu { inherit generic system; };
-  debian = pkgs.callPackage ./debian { inherit generic system; };
-  fedora = pkgs.callPackage ./fedora { inherit generic system; };
-  rocky = pkgs.callPackage ./rocky { inherit generic system; };
+
+  hostSystem = system;
+  guestSystem = import ./systems.nix hostSystem;
+
+  # `hostPkgs`  runs the driver/QEMU (darwin on a Mac); `guestPkgs` is always a
+  # Linux set used for the guest image and anything executed inside the VM.
+  hostPkgs = import nixpkgs { system = hostSystem; };
+  guestPkgs =
+    if guestSystem == hostSystem
+    then hostPkgs
+    else import nixpkgs { system = guestSystem; };
+
+  generic = hostPkgs.callPackage ./generic {
+    inherit nixpkgs hostPkgs guestPkgs hostSystem guestSystem;
+  };
+  ubuntu = hostPkgs.callPackage ./ubuntu { inherit generic guestPkgs guestSystem; };
+  debian = hostPkgs.callPackage ./debian { inherit generic guestPkgs guestSystem; };
+  fedora = hostPkgs.callPackage ./fedora { inherit generic guestPkgs guestSystem; };
+  rocky = hostPkgs.callPackage ./rocky { inherit generic guestPkgs guestSystem; };
   # Function that can be used when defining inline modules to get better location
   # reporting in module-system errors.
   # Usage example:

--- a/overlay.nix
+++ b/overlay.nix
@@ -2,11 +2,26 @@ final: prev:
 
 let
   inherit (prev.stdenv.hostPlatform) system;
-  generic = import ./generic { inherit (prev) lib; pkgs = final; nixpkgs = prev.path; };
-  ubuntu = prev.callPackage ./ubuntu { inherit generic system; };
-  debian = prev.callPackage ./debian { inherit generic system; };
-  fedora = prev.callPackage ./fedora { inherit generic system; };
-  rocky = prev.callPackage ./rocky { inherit generic system; };
+  hostSystem = system;
+  guestSystem = import ./systems.nix hostSystem;
+
+  # On a Linux host the guest packages are just `final`; on darwin we need a
+  # Linux package set for the guest image and in-VM binaries.
+  guestPkgs =
+    if guestSystem == hostSystem
+    then final
+    else import prev.path { system = guestSystem; };
+
+  generic = import ./generic {
+    inherit (prev) lib;
+    hostPkgs = final;
+    inherit guestPkgs hostSystem guestSystem;
+    nixpkgs = prev.path;
+  };
+  ubuntu = prev.callPackage ./ubuntu { inherit generic guestPkgs guestSystem; };
+  debian = prev.callPackage ./debian { inherit generic guestPkgs guestSystem; };
+  fedora = prev.callPackage ./fedora { inherit generic guestPkgs guestSystem; };
+  rocky = prev.callPackage ./rocky { inherit generic guestPkgs guestSystem; };
 in
 
 {

--- a/rocky/default.nix
+++ b/rocky/default.nix
@@ -1,22 +1,116 @@
-{ generic, pkgs, lib, system }:
+{ generic, guestPkgs, lib, guestSystem }:
 let
   imagesJSON = lib.importJSON ./images.json;
-  fetchImage = image: pkgs.fetchurl {
+  fetchImage = image: guestPkgs.fetchurl {
     inherit (image) sha256;
     url = image.url;
   };
-  images = lib.mapAttrs (k: v: fetchImage v) (imagesJSON.${system} or {});
-  makeVmTestForImage = imageID: image: { testScript, sharedDirs ? {}, diskSize ? null, extraPathsToRegister ? [ ], memorySize ? null, cpus ? null }: generic.makeVmTest {
+
+  # Rocky/RHEL 8.x aarch64 kernels are built with 64 KB memory pages. Not every
+  # aarch64 CPU implements that translation granule (notably Apple Silicon, which
+  # only supports 4 KB/16 KB) — on one that doesn't, the kernel's EFI stub refuses
+  # to boot ("64 KB granular kernel is not supported by your CPU") and the VM just
+  # hangs. This is a guest-architecture concern, not a darwin-specific one (e.g. an
+  # aarch64-linux host with a similarly-limited CPU would hit it too), so filter
+  # for any aarch64 guest rather than only when the host happens to be darwin.
+  imagesForSystem = imagesJSON.${guestSystem} or { };
+  supportedImages =
+    if generic.guestIsAarch64
+    then lib.filterAttrs (name: _: !(lib.hasPrefix "8_" name)) imagesForSystem
+    else imagesForSystem;
+  images = lib.mapAttrs (k: v: fetchImage v) supportedImages;
+
+  # aarch64 has no guestfs; customize via a cloud-init seed at boot instead.
+  # RHEL clones disable the 9p filesystem in their kernels, so (as in the baked
+  # path) there is no mounted nix store: the backdoor script is a standalone
+  # /bin/bash script copied into /usr/bin.
+  useCloudInit = generic.guestIsAarch64;
+
+  # Lock repositories to the vault mirror for the image's own minor version, so
+  # dnf operations against first-party repos keep working even after that point
+  # release is superseded — every image in rocky/images.json already points at
+  # `vault/rocky`, so this isn't hypothetical, it's the state of every image we
+  # ship. Safe to apply to every repo file since a fresh RESF image ships no
+  # non-first-party repos. Kept as plain text (rather than a derivation) so it
+  # can be spliced directly into the baked path's guestfs `--run` script (whose
+  # own store-path references aren't visible inside the libguestfs chroot) as
+  # well as copied onto the cloud-init seed for the boot-time path.
+  rockyFixReposScriptText = ''
+    rockyRepoFiles=( $(find /etc/yum.repos.d -type f 2>/dev/null) )
+    for repoFile in "''${rockyRepoFiles[@]}"; do
+      sed -i 's@.*mirrorlist=@#mirrorlist=@g' "''${repoFile}" # disable mirrorlist
+      sed -i 's@.*baseurl=@baseurl=@g' "''${repoFile}" # switch to fastly CDN
+
+      # `pub/rocky` is for non-EoL, `vault/rocky` is for EoL
+      sed -i 's@$contentdir@vault/rocky@g' "''${repoFile}"
+      sed -i 's@pub/rocky@vault/rocky@g' "''${repoFile}"
+
+      # all this to not pollute the current environment with $VERSION_ID
+      (export $(cat /etc/os-release | grep '^VERSION_ID=' | sed -e 's/"//g') && sed -i "s@\$releasever@''${VERSION_ID}@g" "''${repoFile}")
+    done
+    # change the value of the `contentdir` DNF variable
+    [ -f /etc/dnf/vars/contentdir ] && sed -i 's@pub/rocky@vault/rocky@g' /etc/dnf/vars/contentdir
+  '';
+
+  resizeRawImage = { originalImage, diskSize }:
+    if diskSize == null then originalImage
+    else guestPkgs.runCommand "${originalImage.name}-resized.qcow2"
+      { nativeBuildInputs = [ guestPkgs.qemu ]; } ''
+        install -m644 ${originalImage} "$out"
+        qemu-img resize "$out" ${diskSize}
+      '';
+
+  # cloud-init's default `growpart`/`resizefs` modules grow the partition/filesystem
+  # on boot (unlike the baked path, cloud-init is still active here, so a custom
+  # resize service would just race it and fail with "NOCHANGE: ... it cannot be
+  # grown" — see resizeService's own comment for why it's baked-path-only).
+  rockyCloudInitSeed =
+    generic.mkCloudInitSeed {
+      files = {
+        "backdoor.service" = generic.backdoor { scriptPath = "/usr/bin/backdoorScript"; withMountedStore = false; };
+        "backdoorScript" = generic.backdoorScript;
+        "fix-repos.sh" = guestPkgs.writeText "fix-rocky-repos.sh" rockyFixReposScriptText;
+      };
+      userData = generic.mkUserData {
+        runcmd = [
+          "mkdir -p /run/nixvmtest-seed"
+          "mount -o ro /dev/disk/by-label/CIDATA /run/nixvmtest-seed"
+          "install -m755 /run/nixvmtest-seed/backdoorScript /usr/bin/backdoorScript"
+          # Patch the store-path shebang to /bin/bash (there is no mounted store here).
+          "sed -i 's|^#!/nix/store/.*|#!/bin/bash|' /usr/bin/backdoorScript"
+          "install -m644 /run/nixvmtest-seed/backdoor.service /etc/systemd/system/backdoor.service"
+          # See rockyFixReposScriptText above for why: every shipped image already
+          # points at a vaulted point release.
+          "bash /run/nixvmtest-seed/fix-repos.sh"
+          "umount /run/nixvmtest-seed"
+          "groupadd -f nixbld"
+          "passwd -d root"
+          "systemctl mask --now serial-getty@${generic.serialConsole}.service serial-getty@hvc0.service"
+          "systemctl mask sshd.service"
+          "systemctl daemon-reload"
+          "systemctl start backdoor.service"
+        ];
+      };
+    };
+
+  makeVmTestForImage = imageID: image: { testScript, sharedDirs ? {}, diskSize ? null, extraPathsToRegister ? [ ], memorySize ? null, cpus ? null }: generic.makeVmTest ({
     name = "vm-test-rocky_${imageID}";
-    inherit system testScript sharedDirs memorySize cpus;
+    inherit testScript sharedDirs memorySize cpus;
+  } // (if useCloudInit then {
+    image = resizeRawImage { originalImage = image; inherit diskSize; };
+    cloudInitSeed = rockyCloudInitSeed;
+  } else {
     image = prepareRockyImage {
       inherit diskSize extraPathsToRegister;
-      hostPkgs = pkgs;
+      # Image preparation is Linux work, so it always runs with `guestPkgs`.
+      buildPkgs = guestPkgs;
       originalImage = image;
     };
-  };
+  }));
 
-  resizeService = pkgs.writeText "resizeService" ''
+  # Baked (x86_64) path only: the aarch64/cloud-init path relies on cloud-init's
+  # own default growpart/resizefs modules instead (see rockyCloudInitSeed above).
+  resizeService = guestPkgs.writeText "resizeService" ''
     [Service]
     Type = oneshot
     ExecStart = growpart /dev/sda 1
@@ -26,9 +120,9 @@ let
     WantedBy = multi-user.target
   '';
 
-  prepareRockyImage = { hostPkgs, originalImage, diskSize, extraPathsToRegister }:
+  prepareRockyImage = { buildPkgs, originalImage, diskSize, extraPathsToRegister }:
     let
-      pkgs = hostPkgs;
+      pkgs = buildPkgs;
       resultImg = "./image.qcow2";
     in
     pkgs.runCommand "${originalImage.name}-nix-vm-test.qcow2" { } ''
@@ -74,7 +168,7 @@ let
           groupadd nixbld
 
           # Don't spawn ttys on these devices, they are used for test instrumentation
-          systemctl mask serial-getty@ttyS0.service
+          systemctl mask serial-getty@${generic.serialConsole}.service
           systemctl mask serial-getty@hvc0.service
 
           # We have no network in the test VMs, avoid an error on bootup
@@ -96,28 +190,7 @@ let
           systemctl enable register-nix-paths.service
           systemctl enable backdoor.service
 
-          # lock repositories to the minor version in vault so that
-          # the dnf operations **always** work for first-party repos
-
-          # safe to do on all repos because you won't find any
-          # non-first-party repos on a fresh image from RESF
-          rockyRepoFiles=( $(find /etc/yum.repos.d -type f 2>/dev/null) )
-          for repoFile in "''${rockyRepoFiles[@]}"; do
-            sed -i 's@.*mirrorlist=@#mirrorlist=@g' "''${repoFile}" # disable mirrorlist
-            sed -i 's@.*baseurl=@baseurl=@g' "''${repoFile}" # switch to fastly CDN
-
-            # `pub/rocky` is for non-EoL, `vault/rocky` is for EoL
-            sed -i 's@$contentdir@vault/rocky@g' "''${repoFile}"
-            sed -i 's@pub/rocky@vault/rocky@g' "''${repoFile}"
-
-            # change `$contentdir` globally
-            sed -i 's@$contentdir@vault/rocky@g' "''${repoFile}"
-
-            # all this to not pollute the current environment with $VERSION_ID
-            (export $(cat /etc/os-release | grep '^VERSION_ID=' | sed -e 's/"//g') && sed -i "s@\$releasever@''${VERSION_ID}@g" "''${repoFile}")
-          done
-          # change the value of the `contentdir` DNF variable
-          [ -f /etc/dnf/vars/contentdir ] && sed -i 's@pub/rocky@vault/rocky@g' /etc/dnf/vars/contentdir
+          ${rockyFixReposScriptText}
         '')
 
       ]};

--- a/systems.nix
+++ b/systems.nix
@@ -1,0 +1,14 @@
+# Maps a host system to the Linux guest system its VMs run as.
+#
+# VM tests always run a Linux guest. On a Linux host the guest matches the host;
+# on darwin we run the same-architecture Linux guest (accelerated via HVF), which
+# requires a Linux builder to build the guest closure.
+hostSystem:
+{
+  "x86_64-linux" = "x86_64-linux";
+  "aarch64-linux" = "aarch64-linux";
+  "aarch64-darwin" = "aarch64-linux";
+}.${hostSystem} or (throw ''
+  nix-vm-test: unsupported host system '${hostSystem}'.
+  Supported host systems: x86_64-linux, aarch64-linux, aarch64-darwin.
+'')

--- a/tests/debian.nix
+++ b/tests/debian.nix
@@ -1,4 +1,4 @@
-{ pkgs, package, system }:
+{ pkgs, package, guestPkgs, system }:
 let
   lib = package;
   multiUserTest = runner: (runner {
@@ -16,6 +16,9 @@ in {
     sharedDirs = {};
     testScript = ''
       vm.wait_for_unit("multi-user.target")
+      # Verify the disk resize didn't leave a failed unit behind (baked path:
+      # our own resizeguest.service; cloud-init path: its built-in growpart).
+      vm.succeed('[ -z "$(systemctl --failed --no-legend)" ]')
     '';
     diskSize = "+2M";
   }).sandboxed;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,9 +1,24 @@
-{ package, pkgs, system }:
+{ package, pkgs, guestPkgs, system }:
 let
   lib = pkgs.lib;
   addPrefixToTests = prefix: tests: lib.mapAttrs' (n: v: lib.nameValuePair (prefix + n) v) tests;
-  ubuntu = addPrefixToTests "ubuntu-" (import ./ubuntu.nix { inherit package pkgs system; });
-  debian = addPrefixToTests "debian-" (import ./debian.nix { inherit package pkgs system; });
-  fedora = addPrefixToTests "fedora-" (import ./fedora.nix { inherit package pkgs system; });
-  rocky = addPrefixToTests "rocky-" (import ./rocky.nix { inherit package pkgs system; });
-in ubuntu // debian // fedora // rocky
+
+  args = { inherit package pkgs guestPkgs system; };
+
+  distros = {
+    ubuntu = ./ubuntu.nix;
+    debian = ./debian.nix;
+    fedora = ./fedora.nix;
+    rocky = ./rocky.nix;
+  };
+
+  # Only build a distro's tests when it actually has images for this system.
+  # E.g. Fedora ships no aarch64 image, so it is skipped on aarch64-darwin.
+  # `optionalAttrs` yields {} for the skipped distros, and `concatMapAttrs`
+  # merges the rest into a single flat set of prefixed tests.
+in
+lib.concatMapAttrs
+  (name: file:
+    lib.optionalAttrs ((package.${name}.images or { }) != { })
+      (addPrefixToTests "${name}-" (import file args)))
+  distros

--- a/tests/fedora.nix
+++ b/tests/fedora.nix
@@ -1,4 +1,4 @@
-{ pkgs, package, system }:
+{ pkgs, package, guestPkgs, system }:
 let
   lib = package;
   multiUserTest = runner: (runner {
@@ -16,6 +16,9 @@ in {
     sharedDirs = {};
     testScript = ''
       vm.wait_for_unit("multi-user.target")
+      # Verify the disk-resize service actually grew the disk (rather than
+      # failing silently against the wrong block device).
+      vm.succeed('systemctl show -p Result resizeguest.service | grep -q "Result=success"')
     '';
     diskSize = "+2M";
   }).sandboxed;

--- a/tests/rocky.nix
+++ b/tests/rocky.nix
@@ -1,4 +1,4 @@
-{ pkgs, package, system }:
+{ pkgs, package, guestPkgs, system }:
 let
   lib = package;
   multiUserTest = runner: (runner {
@@ -11,6 +11,17 @@ let
     pkgs.lib.mapAttrs'
     (n: v: pkgs.lib.nameValuePair "${n}-multi-user-test" (test lib.rocky.${n}))
     lib.rocky.images;
-in
+in {
+  resizeImage = (lib.rocky."10_1" {
+    sharedDirs = {};
+    testScript = ''
+      vm.wait_for_unit("multi-user.target")
+      # Verify the disk resize didn't leave a failed unit behind (baked path:
+      # our own resizeguest.service; cloud-init path: its built-in growpart).
+      vm.succeed('[ -z "$(systemctl --failed --no-legend)" ]')
+    '';
+    diskSize = "+2M";
+  }).sandboxed;
+} //
 runTestOnEveryImage multiUserTest //
 package.rocky.images

--- a/tests/ubuntu.nix
+++ b/tests/ubuntu.nix
@@ -1,4 +1,4 @@
-{ pkgs, package, system }:
+{ pkgs, package, guestPkgs, system }:
 
 let
   lib = package;
@@ -17,6 +17,9 @@ in {
     sharedDirs = {};
     testScript = ''
       vm.wait_for_unit("multi-user.target")
+      # Verify the disk resize didn't leave a failed unit behind (baked path:
+      # our own resizeguest.service; cloud-init path: its built-in growpart).
+      vm.succeed('[ -z "$(systemctl --failed --no-legend)" ]')
     '';
     diskSize = "+2M";
   }).sandboxed;
@@ -58,13 +61,16 @@ in {
   }).sandboxed;
 
   pathsToRegisterTest = let
-    testPackage = pkgs.runCommandNoCC "test-package" {} ''
+    # This package is shared into the guest and its path is executed/registered
+    # there, so it must be a Linux (guest) store path — build it with guestPkgs.
+    testPackage = guestPkgs.runCommandNoCC "test-package" {} ''
       mkdir -p $out/bin
       echo '#!/bin/sh' > $out/bin/test-tool
       echo 'echo "Hello from test-package"' >> $out/bin/test-tool
       chmod +x $out/bin/test-tool
     '';
-    nixStoreBin = "${pkgs.lib.getBin pkgs.nix}/bin/nix-store";
+    # `nix-store` here runs inside the guest, so it also has to be the Linux build.
+    nixStoreBin = "${pkgs.lib.getBin guestPkgs.nix}/bin/nix-store";
   in (lib.ubuntu."23_04" {
     sharedDirs = {};
     testScript = ''

--- a/ubuntu/default.nix
+++ b/ubuntu/default.nix
@@ -1,23 +1,82 @@
-{ generic, pkgs, lib, system }:
+{ generic, guestPkgs, lib, guestSystem }:
 let
   imagesJSON = lib.importJSON ./images.json;
-  fetchImage = image: pkgs.fetchurl {
+  fetchImage = image: guestPkgs.fetchurl {
     sha256 = image.hash;
     url = image.name;
   };
-  images = lib.mapAttrs (k: v: fetchImage v) imagesJSON.${system};
-  makeVmTestForImage = imageID: image: { testScript, sharedDirs ? {}, diskSize ? null, extraPathsToRegister ? [ ], memorySize ? null, cpus ? null }: generic.makeVmTest {
+  images = lib.mapAttrs (k: v: fetchImage v) (imagesJSON.${guestSystem} or {});
+
+  # `guestfs`/`virt-customize` is unavailable on aarch64, so there we skip the
+  # image bake and customize via a cloud-init seed at boot instead (see below).
+  useCloudInit = generic.guestIsAarch64;
+
+  # Grow the raw cloud image (guestfs-free) when a diskSize is requested. cloud-init's
+  # default `growpart`/`resizefs` modules then grow the partition/filesystem on boot
+  # (unlike the baked path, cloud-init is still active here, so a custom resize
+  # service would just race it and fail with "NOCHANGE: ... it cannot be grown").
+  resizeRawImage = { originalImage, diskSize }:
+    if diskSize == null then originalImage
+    else guestPkgs.runCommand "${originalImage.name}-resized.qcow2"
+      { nativeBuildInputs = [ guestPkgs.qemu ]; } ''
+        install -m644 ${originalImage} "$out"
+        qemu-img resize "$out" ${diskSize}
+      '';
+
+  ubuntuCloudInitSeed = { extraPathsToRegister }:
+    generic.mkCloudInitSeed {
+      files = {
+        "backdoor.service" = generic.backdoor { };
+        "mount-store.service" = generic.mountStore { pathsToRegister = extraPathsToRegister; };
+        # Mirror the sudoers tweak the baked image applies (keeps sudo output clean
+        # for the test driver).
+        "disable-pty" = guestPkgs.writeText "disable-pty" ''
+          Defaults !requiretty
+          Defaults !use_pty
+        '';
+      };
+      userData = generic.mkUserData {
+        runcmd = [
+          "mkdir -p /run/nixvmtest-seed"
+          "mount -o ro /dev/disk/by-label/CIDATA /run/nixvmtest-seed"
+          "install -m644 /run/nixvmtest-seed/backdoor.service /etc/systemd/system/backdoor.service"
+          "install -m644 /run/nixvmtest-seed/mount-store.service /etc/systemd/system/mount-store.service"
+          "install -m440 /run/nixvmtest-seed/disable-pty /etc/sudoers.d/disable-pty"
+          "umount /run/nixvmtest-seed"
+          "passwd -d root"
+          # `--now` also stops any getty already running on these instrumentation
+          # devices, so the backdoor can take over hvc0 without contention.
+          "systemctl mask --now serial-getty@${generic.serialConsole}.service serial-getty@hvc0.service"
+          "systemctl mask snapd.service snapd.socket snapd.seeded.service"
+          "systemctl mask ssh.service ssh.socket"
+          "systemctl daemon-reload"
+          # Start only the backdoor: its Requires/After pulls mount-store into the
+          # same transaction and runs it exactly once. Activating mount-store
+          # separately would re-trigger it (it is a oneshot without RemainAfterExit),
+          # and the second 9p mount fails ("no channels available for device nix-store").
+          "systemctl start backdoor.service"
+        ];
+      };
+    };
+
+  makeVmTestForImage = imageID: image: { testScript, sharedDirs ? {}, diskSize ? null, extraPathsToRegister ? [ ], memorySize ? null, cpus ? null }: generic.makeVmTest ({
     name = "vm-test-ubuntu_${imageID}";
-    inherit system testScript sharedDirs memorySize cpus;
+    inherit testScript sharedDirs memorySize cpus;
+  } // (if useCloudInit then {
+    image = resizeRawImage { originalImage = image; inherit diskSize; };
+    cloudInitSeed = ubuntuCloudInitSeed { inherit extraPathsToRegister; };
+  } else {
     image = prepareUbuntuImage {
       inherit diskSize extraPathsToRegister;
-      hostPkgs = pkgs;
+      # Image preparation is Linux work (guestfs + guest binaries baked into the
+      # image), so it always runs with the Linux `guestPkgs` set.
+      buildPkgs = guestPkgs;
       originalImage = image;
     };
-  };
-  prepareUbuntuImage = { hostPkgs, originalImage, diskSize, extraPathsToRegister }:
+  }));
+  prepareUbuntuImage = { buildPkgs, originalImage, diskSize, extraPathsToRegister }:
     let
-      pkgs = hostPkgs;
+      pkgs = buildPkgs;
       resultImg = "./image.qcow2";
     in
     pkgs.runCommand "${originalImage.name}-nix-vm-test.qcow2" { } ''
@@ -51,7 +110,7 @@ let
           passwd -d root
 
           # Don't spawn ttys on these devices, they are used for test instrumentation
-          systemctl mask serial-getty@ttyS0.service
+          systemctl mask serial-getty@${generic.serialConsole}.service
           systemctl mask serial-getty@hvc0.service
           # Speed up the boot process
           systemctl mask snapd.service


### PR DESCRIPTION
Hi!

I had seen issue #97 opened a while ago and tried to give it a shot (CC @samrose you might want to review this as well!) I have been running these successfully (Ubuntu/Debian VMs, nixpkgs 26.05) for some private projects, so decided to open.

Found some issues that made the implementation not trivial such as  `libguestfs-appliance` not being available for `aarch64-linux`, which meant switching to a cloud-init strategy... Let me know your thoughts.

Closes #97 