### PR TITLE
fix: update rocky 10.1 image URLs to vault 

### DIFF
--- a/rocky/images.json
+++ b/rocky/images.json
@@ -57,7 +57,7 @@
       "sha256": "0jhfnggfp5ywbqmxz1cb9lhvxlm8zffw8h5l5a7c44f0gk0v4xip"
     },
     "10_1": {
-      "url": "https://download.rockylinux.org/pub/rocky/10.1/images/aarch64/Rocky-10-GenericCloud-Base-10.1-20251116.0.aarch64.qcow2",
+      "url": "https://download.rockylinux.org/vault/rocky/10.1/images/aarch64/Rocky-10-GenericCloud-Base-10.1-20251116.0.aarch64.qcow2",
       "name": "Rocky-10.1-GenericCloud.aarch64.qcow2",
       "sha256": "0vg3ir1ishq9581rpmzl2c6vlm62kfkkb9wg2cr5ahgvz0y05h5b"
     }
@@ -121,7 +121,7 @@
       "sha256": "0g8ad60a62hk0bxw6icavci3f0sjkc77h127vszcrb9wp1dq2wic"
     },
     "10_1": {
-      "url": "https://download.rockylinux.org/pub/rocky/10.1/images/x86_64/Rocky-10-GenericCloud-Base-10.1-20251116.0.x86_64.qcow2",
+      "url": "https://download.rockylinux.org/vault/rocky/10.1/images/x86_64/Rocky-10-GenericCloud-Base-10.1-20251116.0.x86_64.qcow2",
       "name": "Rocky-10.1-GenericCloud.x86_64.qcow2",
       "sha256": "1ba7qdmnvmkc5jp998kdka8ib1w9yb1wmjzcw7wwcd5112zqlqi8"
     }


### PR DESCRIPTION
Rocky 10.1 was moved out of `pub/rocky/10.1/` into `vault/rocky/10.1/`, the old URLs now are 404.

While working on #187 found this so also thought on fixing.