### PR TITLE
ci(update-images): update existing PR instead of opening a new one

### DIFF
--- a/.github/workflows/update-images.yml
+++ b/.github/workflows/update-images.yml
@@ -28,15 +28,19 @@ jobs:
             git diff
             git config user.name github-actions
             git config user.email github-actions@github.com
-            branchname="update-images-$(date +%F)"
+            branchname="update-images"
             git checkout -b "${branchname}"
             git add debian/images.json
             git add ubuntu/images.json
             git commit -m "Update images: $(date +%F)"
-            git push origin "${branchname}"
-            gh pr create -B main -H "${branchname}" \
-              --title 'Bump images.json' \
-              --body 'PR generated using scripts/update-images.py'
+            git push --force origin "${branchname}"
+            if [[ -n $(gh pr list --head "${branchname}" --state open --json number --jq '.[].number') ]]; then
+              echo "Existing PR updated"
+            else
+              gh pr create -B main -H "${branchname}" \
+                --title 'Bump images.json' \
+                --body 'PR generated using scripts/update-images.py'
+            fi
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use a single long-lived 'update-images' branch and force-push it, so a pending PR is refreshed when it is not reviewed before the next weekly run. Only open a PR when none is already open for the branch.